### PR TITLE
Better default regex to support jsx and tailwind

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,11 @@
 					"type": "string",
 					"order": 1,
 					"description": "Regex to match",
-					"default": "class=\"([a-zA-Z0-9-\\s]+)(?=\")",
+					"default": "(class|className)=\"([a-zA-Z0-9-:\\s]+)(?=\")",
 					"examples": [
 						"class=\"([a-zA-Z0-9-\\s]+)(?=\")",
-						"id=\"([a-zA-Z0-9-\\s]+)(?=\")"
+						"id=\"([a-zA-Z0-9-\\s]+)(?=\")",
+						"(class|className)=\"([a-zA-Z0-9-:\\s]+)(?=\")"
 					]
 				},
 				"inlineFold.regexFlags": {


### PR DESCRIPTION
JSX (used mainly with React.js) uses the attribute "className" instead of "class". Also, Tailwind CSS uses columns in some of its classes (e.g. hover:underline). I think it would be good to support both React/JSX and Tailwind "out of the box" as they are both very popular