### PR TITLE
Fix regex matching many characters as possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 					"type": "string",
 					"order": 1,
 					"description": "Regex to match",
-					"default": "(class|className)=[`'{\"]([^`'\"}]+)[`'\"}]",
+					"default": "(class|className)=([`'\"{])([^`'\"}].*?)(\\2|})",
 					"examples": [
 						"(class|className)=[`'{\"]([^`'\"}]+)[`'\"}]",
 						"class=\"([a-zA-Z0-9-\\s]+)(?=\")",


### PR DESCRIPTION
This is my [regex test](https://regexr.com/6q6ih)

regex matches as many characters as possible, Such as

```
<div :class="isDark ? 'dark' : 'light'" />

<div className={isDark" ? 'dark': 'light'} />
```
